### PR TITLE
Can not jump to neither 1.3.x or 1.4.x because slf4j-api should stay …

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.4.5</version>
+            <version>1.2.11</version>
             <scope>runtime</scope>
         </dependency>
 


### PR DESCRIPTION
…lower 2.x by compatibilty